### PR TITLE
Adds Finds support to is_element_present()

### DIFF
--- a/docs/is_element_present.rst
+++ b/docs/is_element_present.rst
@@ -7,6 +7,13 @@ It returns if an element with corresponding name is shown on the page.
 
 .. literalinclude:: ../examples/12_is_element_present.py
 
+*Note*: Containers with elements located via ``Finds`` also support
+``is_element_present``, albeit with special behaviour. Since the attribute will
+be a list of elements, rather than a single element, ``True`` will be returned
+only if all elements in the list are present. In the event that no elements are
+found (i.e. an empty list), or one or more elements do not qualify as present,
+``False`` will be returned.
+
 just_in_dom
 -----------
 

--- a/tests/simple_page/test_is_element_present.py
+++ b/tests/simple_page/test_is_element_present.py
@@ -8,5 +8,11 @@ class TestIsElementPresent(SimplePageTest):
         ok_(self.page.is_element_present('icon_link'))
         assert_false(self.page.is_element_present('unexistent_element'))
 
+    def test_is_element_present_via_finds(self):
+        ok_(self.page.is_element_present('anchor_list'))
+
+    def test_is_element_present_via_finds_empty_list(self):
+        assert_false(self.page.is_element_present('empty_element_list'))
+
     def test_no_attribute(self):
         assert_raises(WebiumException, self.page.is_element_present, 'no_such_attribute')

--- a/webium/base_page.py
+++ b/webium/base_page.py
@@ -21,9 +21,15 @@ def is_element_present(self, element_name, just_in_dom=False, timeout=0):
     _get_driver().implicitly_wait(timeout)
     try:
         def is_displayed():
-            element = getattr(self, element_name, None)
-            if not element:
+            try:
+                element = getattr(self, element_name)
+            except AttributeError:
                 raise WebiumException('No element "{0}" within container {1}'.format(element_name, self))
+            if isinstance(element, list):
+                if element:
+                    return all(ele.is_displayed() for ele in element)
+                else:
+                    return False
             return element.is_displayed()
 
         is_displayed() if just_in_dom else wait(lambda: is_displayed(), timeout_seconds=timeout)


### PR DESCRIPTION
**Context**
I'm still quite new to the page object design pattern, so this may not normally come up. I have a table of elements that need to be deleted one at a time via a menu/option. My solution is to iterate while there are still elements visible and delete them one at a time (avoiding the stale element reference in doing so). The problem is that Webium's nice `is_element_present()` method fails for Finds. This is my fix, which seems to work for me, and should not break existing behaviour. The question is, if it should check that all elements are visible, or if only the first is necessary...

**Error Encountered**
```
ntp.py:42: in delete_all
    while self.is_element_present('ntp_servers'):
/usr/lib/python3.5/site-packages/webium/base_page.py:29: in is_element_present
    is_displayed() if just_in_dom else wait(lambda: is_displayed(), timeout_seconds=timeout)
/usr/lib/python3.5/site-packages/webium/wait.py:16: in wait
    return wait_lib(*args, **kwargs)
/usr/lib/python3.5/site-packages/waiting/__init__.py:16: in wait
    for x in iterwait(result=result, *args, **kwargs):
/usr/lib/python3.5/site-packages/waiting/__init__.py:40: in iterwait
    result.result = predicate()
/usr/lib/python3.5/site-packages/webium/base_page.py:29: in <lambda>
    is_displayed() if just_in_dom else wait(lambda: is_displayed(), timeout_seconds=timeout)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    def is_displayed():
        element = getattr(self, element_name, None)
        if not element:
            raise WebiumException('No element "{0}" within container {1}'.format(element_name, self))
>       return element.is_displayed()
E       AttributeError: 'list' object has no attribute 'is_displayed'
```